### PR TITLE
remove github-remote config from .cursor/mcp.json

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -5,10 +5,6 @@
       "args": [
         "-y @modelcontextprotocol/server-postgres postgresql://postgres:postgres@localhost:5436/postgres"
       ]
-    },
-    "github-remote": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
     }
   }
 }


### PR DESCRIPTION
`.cursor/mcp.json` から `github-remote` 設定を削除しました。不要な設定のため削除します。